### PR TITLE
Field serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ coverage.xml
 .pytest_cache/
 .tox/
 .idea/
+Pipfile
 Pipfile.lock

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 combine_as_imports = true
 default_section = THIRDPARTY
 include_trailing_comma = true
-known_first_party = etools_validator,tests
+known_first_party = etools_validator,tests,demo
 multi_line_output = 3
 line_length=120
 balanced_wrapping = true

--- a/src/etools_validator/mixins.py
+++ b/src/etools_validator/mixins.py
@@ -98,6 +98,17 @@ class ValidatorViewMixin(object):
 
         old_instance = self.get_object()
         instance = self.get_object()
+
+        old_related_data = []
+        for field in kwargs.get("related_non_serialized_fields", []):
+            rel_field_val = getattr(instance, field, None)
+            prop = f"{field}_old"
+            if rel_field_val is None:
+                val = None
+            else:
+                val = list(rel_field_val.all())
+            old_related_data.append((prop, val))
+
         main_serializer = self.get_serializer(
             instance,
             data=data,
@@ -126,5 +137,8 @@ class ValidatorViewMixin(object):
 
         for k, v in my_relations.items():
             self.up_related_field(main_object, v, k, partial, nested_related_names)
+
+        for field, val in old_related_data:
+            setattr(old_instance, field, val)
 
         return self.get_object(), old_instance, main_serializer

--- a/src/etools_validator/mixins.py
+++ b/src/etools_validator/mixins.py
@@ -31,6 +31,7 @@ class ValidatorViewMixin(object):
                 k: v for k, v in field.items()
                 if k in nested_related_names
             }
+        nested_related_data["request"] = self.request
         if field.get('id', None):
             try:
                 instance = fieldClass.objects.get(id=field['id'])

--- a/src/etools_validator/utils.py
+++ b/src/etools_validator/utils.py
@@ -125,8 +125,7 @@ def check_rigid_fields(obj, fields, old_instance=None, related=False):
 
 def update_object(obj, kwdict):
     for k, v in kwdict.items():
-        attr = getattr(obj, k, None)
-        if isinstance(v, list) and not isinstance(attr, list):
-            attr.set(v)
+        if isinstance(v, list):
+            getattr(obj, k).set(v)
         else:
             setattr(obj, k, v)

--- a/src/etools_validator/utils.py
+++ b/src/etools_validator/utils.py
@@ -125,7 +125,7 @@ def check_rigid_fields(obj, fields, old_instance=None, related=False):
 
 def update_object(obj, kwdict):
     for k, v in kwdict.items():
-        attr = getattr(obj, k)
+        attr = getattr(obj, k, None)
         if isinstance(v, list) and not isinstance(attr, list):
             attr.set(v)
         else:

--- a/src/etools_validator/utils.py
+++ b/src/etools_validator/utils.py
@@ -125,7 +125,8 @@ def check_rigid_fields(obj, fields, old_instance=None, related=False):
 
 def update_object(obj, kwdict):
     for k, v in kwdict.items():
-        if isinstance(v, list):
-            getattr(obj, k).set(v)
+        attr = getattr(obj, k)
+        if isinstance(v, list) and not isinstance(attr, list):
+            attr.set(v)
         else:
             setattr(obj, k, v)

--- a/tests/demoproject/demo/factories.py
+++ b/tests/demoproject/demo/factories.py
@@ -1,7 +1,6 @@
+import factory
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
-
-import factory
 from factory import fuzzy
 
 from demo.sample import models

--- a/tests/demoproject/demo/factories.py
+++ b/tests/demoproject/demo/factories.py
@@ -26,6 +26,13 @@ class SpecialModelFactory(factory.django.DjangoModelFactory):
         model = models.SpecialModel
 
 
+class ManyModelFactory(factory.django.DjangoModelFactory):
+    name = fuzzy.FuzzyText(length=50)
+
+    class Meta:
+        model = models.ManyModel
+
+
 class UserFactory(factory.django.DjangoModelFactory):
     username = fuzzy.FuzzyText(length=50)
 

--- a/tests/demoproject/demo/sample/models.py
+++ b/tests/demoproject/demo/sample/models.py
@@ -21,6 +21,7 @@ class DemoModel(models.Model):
     description = models.TextField(blank=True)
     document = models.FileField(null=True, blank=True)
     status = FSMField(default=STATUS_NEW, choices=STATUS_CHOICES)
+    others = models.ManyToManyField("sample.ManyModel", blank=True)
 
     def permission_structure(self):
         return None
@@ -75,3 +76,7 @@ class SpecialModel(models.Model):
         on_delete=models.CASCADE,
         related_name="special"
     )
+
+
+class ManyModel(models.Model):
+    name = models.CharField(max_length=50)

--- a/tests/demoproject/demo/sample/permissions.py
+++ b/tests/demoproject/demo/sample/permissions.py
@@ -15,5 +15,6 @@ class DemoModelPermissions(object):
                 "description": "edit",
                 "status": "edit",
                 "document": "edit",
+                "others": "view",
             }
         }

--- a/tests/demoproject/demo/sample/urls.py
+++ b/tests/demoproject/demo/sample/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 
-from .views import DemoCreateView, DemoUpdateView
+from .views import DemoCreateView, DemoUpdateNonSerializedView, DemoUpdateView
 
 app_name = "sample"
 
@@ -10,5 +10,10 @@ urlpatterns = (
         r'^update/(?P<pk>\d+)/$',
         view=DemoUpdateView.as_view(),
         name='update'
+    ),
+    url(
+        r'^update-non-serialized/(?P<pk>\d+)/$',
+        view=DemoUpdateNonSerializedView.as_view(),
+        name='update-non-serialized'
     ),
 )

--- a/tests/demoproject/demo/sample/views.py
+++ b/tests/demoproject/demo/sample/views.py
@@ -71,3 +71,34 @@ class DemoUpdateView(ValidatorViewMixin, UpdateAPIView):
                 context=self.get_serializer_context()
             ).data
         )
+
+
+class DemoUpdateNonSerializedView(ValidatorViewMixin, UpdateAPIView):
+    queryset = DemoModel.objects.all()
+    serializer_class = DemoModelSerializer
+
+    def update(self, request, *args, **kwargs):
+        related_fields = []
+        related_non_serialized_fields = ['others']
+        instance, old_instance, serializer = self.my_update(
+            request,
+            related_fields,
+            related_non_serialized_fields=related_non_serialized_fields,
+            **kwargs
+        )
+
+        validator = DemoModelValidation(
+            instance,
+            old=old_instance,
+            user=request.user
+        )
+
+        if not validator.is_valid:
+            raise ValidationError(validator.errors)
+
+        return Response(
+            DemoModelSerializer(
+                instance,
+                context=self.get_serializer_context()
+            ).data
+        )

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,13 +1,13 @@
 from unittest import TestCase
 
 import pytest
-from demo.factories import DemoChildModelFactory, DemoModelFactory, ManyModelFactory, SpecialModelFactory, UserFactory
-from demo.sample.models import DemoChildModel, DemoModel, SpecialModel
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import resolve, reverse
 from rest_framework import status
 from rest_framework.test import APIRequestFactory, force_authenticate
 
+from demo.factories import DemoChildModelFactory, DemoModelFactory, ManyModelFactory, SpecialModelFactory, UserFactory
+from demo.sample.models import DemoChildModel, DemoModel, SpecialModel
 from etools_validator.mixins import ValidatorViewMixin
 
 pytestmark = pytest.mark.django_db

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,15 +1,14 @@
+from unittest import TestCase
+
+import pytest
+from demo.factories import DemoChildModelFactory, DemoModelFactory, ManyModelFactory, SpecialModelFactory, UserFactory
+from demo.sample.models import DemoChildModel, DemoModel, SpecialModel
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import resolve, reverse
 from rest_framework import status
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-import pytest
-from unittest import TestCase
-
 from etools_validator.mixins import ValidatorViewMixin
-
-from demo.factories import DemoChildModelFactory, DemoModelFactory, SpecialModelFactory, UserFactory
-from demo.sample.models import DemoChildModel, DemoModel, SpecialModel
 
 pytestmark = pytest.mark.django_db
 
@@ -126,6 +125,25 @@ class TestValidatorViewMixin(TestCase):
         self.assertEqual(response.data["name"], "New")
         special_updated = SpecialModel.objects.get(pk=special.pk)
         self.assertEqual(special_updated.name, "Updated Special")
+
+    def test_update_non_serialized_update(self):
+        m = DemoModelFactory(name="Old", document="test.txt")
+        self.assertEqual(list(m.others.all()), [])
+        one = ManyModelFactory()
+        response = self._get_response(
+            "put",
+            reverse("sample:update-non-serialized", args=[m.pk]),
+            {
+                "name": "New",
+                "others": [one.pk],
+            },
+            format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], m.pk)
+        self.assertEqual(response.data["name"], "New")
+        m.refresh_from_db()
+        self.assertEqual(list(m.others.all()), [one])
 
     def test_update_children_create(self):
         m = DemoModelFactory(name="Old", document="test.txt")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,10 @@
-import pytest
 from unittest import TestCase
 
-from etools_validator import utils
+import pytest
 
 from demo.factories import DemoChildModelFactory, DemoModelFactory
 from demo.sample import models
+from etools_validator import utils
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,7 @@ class TestGetAllFieldNames(TestCase):
             "children",
             "demomodelnoauto",
             "special",
+            "others",
         ])
 
     def test_related(self):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -146,6 +146,7 @@ class TestCompleteValidation(TestCase):
                 "description": "edit",
                 "status": "edit",
                 "document": "edit",
+                "others": "view",
             }
         })
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,15 +1,14 @@
-from django.contrib.contenttypes.models import ContentType
-
-import pytest
 from unittest import TestCase
 
-from etools_validator.exceptions import TransitionError
-from etools_validator.validation import CompleteValidation
+import pytest
+from django.contrib.contenttypes.models import ContentType
 
 from demo.factories import DemoModelFactory, PermissionFactory, UserFactory
 from demo.sample.models import DemoModel, DemoModelNoAuto
 from demo.sample.permissions import DemoModelPermissions
 from demo.sample.validations import DemoModelValidation
+from etools_validator.exceptions import TransitionError
+from etools_validator.validation import CompleteValidation
 
 pytestmark = pytest.mark.django_db
 


### PR DESCRIPTION
Tweak `update_object` to handle an `arrayfield`

Add `related_non_serialized_fields` param option to `ValidatorViewMixin`
This is for related fields that may have related permissions set, but no serializer for them